### PR TITLE
Make what nohost does and doesn't do a bit clearer up-front

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,23 @@
 nohost
 ======
 
-A web server in your web browser.
+Nohost simulates a static content web server in your browser.  It does this by using JavaScript to read the query string out of the address bar, and then overwrites what was *actually* served with content from the [Filer](https://github.com/js-platform/filer) virtual filesystem at that path location.  Since the filesystem survives between executions of the page, there is stability between various requests.
 
-Running a local web server allows for easier testing and development without the need for a network. The nohost web server takes this a step futher, and allows web sites to be hosted inside the browser without any server or network.
+Each request for a path involves rewriting.  The requested file read and parsed, and processed so as to inline any external resources (e.g., images, stylesheets, etc).  When the document is done being processed, it is again turned into text, and `document.write` is used to replace the web server's boot page with the new content.  Some special pages are synthesized, similar to how a normal web server works.  For example: directory listings and images.
 
-nohost was created in order to make it easier to do in browser, live previews of complex web sites and applications
-that span many files.
+*Note that this doesn't actually "serve" anything.*  So one tab cannot make an XMLHttpRequest() of another--much less could another browser on your system access the data via a local URI.  But it does make it easier to do in-browser, live previews of complex web sites and applications that span many files.
 
 ###Demo
 
 You can try a [demo here](http://humphd.github.io/nohost).
 
-Like any web server, you must first install what you want to serve. The nohost server uses [Filer](https://github.com/js-platform/filer) in order to create a filesystem within the browser.
-Files are then installed in the filesystem using the `?install` boot option, and choosing a disk
-image (*.zip). A demo disk image is included, which can be installed by doing the following:
+nohost boots the web server whenever you load its `index.html` page. Boot options are read from the query string and then actions are taken using the filesystem. 
+
+Like any web server, you must first install what you want to serve.  Files are then installed in the filesystem using the `?install` boot option, and choosing a disk image (*.zip). A demo disk image is included, which can be installed by doing the following:
 
 [http://humphd.github.io/nohost?install=webmaker-kits-gh-pages.zip](http://humphd.github.io/nohost?install=webmaker-kits-gh-pages.zip)
 
-Once installed, the filesystem will survive the server being started and stopped (i.e., closing the window).
-If you want to clear the filesystem, use the `?reset` boot option:
+Once installed, the filesystem will survive the server being started and stopped (i.e., closing the window).  If you want to clear the filesystem, use the `?reset` boot option:
 
 [http://humphd.github.io/nohost?reset](http://humphd.github.io/nohost?reset)
 
@@ -31,13 +29,3 @@ Now that files are installed into the fileystem, you can browse them by adding a
 Any path not found in the filesystem will produce a 404:
 
 [http://humphd.github.io/nohost/?/nothere](http://humphd.github.io/nohost/?/nothere)
-
-###How it Works
-
-nohost boots the web server whenever you load its `index.html` page. Boot options are read from the query string
-and then actions are taken using the filesystem. Since the filesystem survives between executions of the page,
-there is stability between various requests.
-
-Each request for a path involves rewriting.  The file at a given path is read and parsed, and processed so as to
-inline any external resources (e.g., images, stylesheets, etc). When the document is done being processed,
-it is again turned into text, and `document.write` is used to replace the web server's boot page with the new content.  Some special pages are synthesized, similar to how a normal web server works.  For example: directory listings and images.


### PR DESCRIPTION
The demo was very cool, and because it said "web server in your browser" I thought it was doing something it wasn't--e.g. registering the browser somehow as a local data source.  After a bit of digging I figured out what it actually did.

Which is still neat, but I think it could be explained more clearly.  This is just a suggestion of the direction of edits to make it so that it would have brought me up to speed quicker, I am not pushing it verbatim.  It really isn't "serving" anything and I think that's an important point...which may have been obvious to some people, but I learned that via trying to use it as a way to make XMLHttpRequests from blocking workers to GUI threads and finding it wasn't the loophole I hoped it might be... :-/